### PR TITLE
React proptypes to use prop-types package and React.component instead of React.createClass

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,9 @@
     "url": "https://github.com/exelban/react-swipe-component/issues"
   },
   "homepage": "https://github.com/exelban/react-swipe-component",
+  "dependencies": {
+    "prop-types": "15.5.8"
+  },
   "devDependencies": {
     "babel-cli": "~6.24.0",
     "babel-preset-es2015": "~6.24.0"

--- a/src/Swipe.js
+++ b/src/Swipe.js
@@ -1,27 +1,16 @@
 const React = require('react');
 const PropTypes = require('prop-types');
 
-const Swipe = React.createClass({
-    displayName: 'Swipe',
-    propTypes: {
-        nodeName: PropTypes.string,
-        mouseSwipe: PropTypes.bool,
-        className: PropTypes.string,
-        onSwipingUp: PropTypes.func,
-        onSwipingRight: PropTypes.func,
-        onSwipingDown: PropTypes.func,
-        onSwipingLeft: PropTypes.func,
-        onSwipedUp: PropTypes.func,
-        onSwipedRight: PropTypes.func,
-        onSwipedDown: PropTypes.func,
-        onSwipedLeft: PropTypes.func,
-        onSwipe: PropTypes.func,
-        delta: PropTypes.number,
-        preventDefaultEvent: PropTypes.bool,
-        style: PropTypes.object
-    },
-    getInitialState() {
-        return {
+class Swipe extends React.Component {
+    constructor() {
+        super();
+        this._mouseStart = this._mouseStart.bind(this);
+        this._mouseMove = this._mouseMove.bind(this);
+        this._mouseEnd = this._mouseEnd.bind(this);
+        this._touchStart = this._touchStart.bind(this);
+        this._touchMove = this._touchMove.bind(this);
+        this._touchEnd = this._touchEnd.bind(this);
+        this.state = {
             x: 0,
             y: 0,
             status: false,
@@ -29,25 +18,29 @@ const Swipe = React.createClass({
             delta: 50,
             preventDefaultEvent: false
         };
-    },
+    }
+
     render() {
         let newProps = {
             onTouchStart: this._touchStart,
             onTouchMove: this._touchMove,
             onTouchEnd: this._touchEnd,
-            className: this.props.className || "",
+            className: this.props.className || '',
             style: this.props.style || {}
         };
-        if (this.props.mouseSwipe){
+        if (this.props.mouseSwipe) {
             newProps.onMouseMove = this._mouseMove;
             newProps.onMouseDown = this._mouseStart;
             newProps.onMouseUp = this._mouseEnd;
         }
-        return React.createElement(this.props.nodeName || "div", newProps, this.props.children);
-    },
-    _mouseStart(e){
-        if(this.props.preventDefaultEvent && this.props.preventDefaultEvent!==this.state.preventDefaultEvent) this.setState({preventDefaultEvent: this.props.preventDefaultEvent});
-        if(this.props.delta && this.props.delta!==this.state.delta) this.setState({delta: this.props.delta});
+        return React.createElement(this.props.nodeName || 'div', newProps, this.props.children);
+    }
+
+    _mouseStart(e) {
+        if (this.props.preventDefaultEvent && this.props.preventDefaultEvent !== this.state.preventDefaultEvent) {
+            this.setState({ preventDefaultEvent: this.props.preventDefaultEvent });
+        }
+        if (this.props.delta && this.props.delta !== this.state.delta) this.setState({ delta: this.props.delta });
 
         this.setState({
             x: Math.abs(e.clientX).toFixed(2),
@@ -55,80 +48,75 @@ const Swipe = React.createClass({
             status: true,
             detected: false
         });
-        if(this.state.preventDefaultEvent) e.preventDefault();
-    },
-    _mouseMove(e){
-        if (this.state.status){
-            let x = (e.clientX).toFixed(2);
-            let y = (e.clientY).toFixed(2);
+        if (this.state.preventDefaultEvent) e.preventDefault();
+    }
+
+    _mouseMove(e) {
+        if (this.state.status) {
+            let x = e.clientX.toFixed(2);
+            let y = e.clientY.toFixed(2);
             let tX = parseFloat((x - this.state.x).toFixed(2));
             let tY = parseFloat((y - this.state.y).toFixed(2));
 
             if (Math.abs(tX) > Math.abs(tY) && this.props.onSwipe) this.props.onSwipe([tX, 0]);
             else if (Math.abs(tX) < Math.abs(tY) && this.props.onSwipe) this.props.onSwipe([0, tY]);
 
-            if(Math.abs(tX)>=this.state.delta){
-                if(tX>this.state.delta){
-                    if(this && this.props && this.props.onSwipingRight) this.props.onSwipingRight(true);
-                    if(this && this.props && this.props.right) this.props.right(true);
+            if (Math.abs(tX) >= this.state.delta) {
+                if (tX > this.state.delta) {
+                    if (this && this.props && this.props.onSwipingRight) this.props.onSwipingRight(true);
+                    if (this && this.props && this.props.right) this.props.right(true);
+                } else if (tX < -this.state.delta) {
+                    if (this && this.props && this.props.onSwipingLeft) this.props.onSwipingLeft(true);
+                    if (this && this.props && this.props.left) this.props.left(true);
                 }
-                else if(tX<(-this.state.delta)){
-                    if(this && this.props && this.props.onSwipingLeft) this.props.onSwipingLeft(true);
-                    if(this && this.props && this.props.left) this.props.left(true);
+            } else if (Math.abs(tY) >= this.state.delta) {
+                if (tY > this.state.delta) {
+                    if (this && this.props && this.props.onSwipingDown) this.props.onSwipingDown(true);
+                } else if (tY < -this.state.delta) {
+                    if (this && this.props && this.props.onSwipingUp) this.props.onSwipingUp(true);
+                    if (this && this.props && this.props.up) this.props.up(true);
                 }
             }
-            else{
-                if(Math.abs(tY)>=this.state.delta){
-                    if(tY>this.state.delta){
-                        if(this && this.props && this.props.onSwipingDown) this.props.onSwipingDown(true);
+
+            if (!this.state.detected) {
+                if (Math.abs(parseFloat(tX)) >= this.state.delta) {
+                    if (parseFloat(tX) > this.state.delta) {
+                        if (this && this.props && this.props.onSwipedRight) this.props.onSwipedRight(true);
+                        this.setState({ detected: true });
+                    } else if (parseFloat(tX) < -this.state.delta) {
+                        if (this && this.props && this.props.onSwipedLeft) this.props.onSwipedLeft(true);
+                        this.setState({ detected: true });
                     }
-                    else if(tY<(-this.state.delta)){
-                        if(this && this.props && this.props.onSwipingUp) this.props.onSwipingUp(true);
-                        if(this && this.props && this.props.up) this.props.up(true);
+                } else if (Math.abs(parseFloat(tY)) >= this.state.delta) {
+                    if (parseFloat(tY) > this.state.delta) {
+                        if (this && this.props && this.props.onSwipedDown) this.props.onSwipedDown(true);
+                        this.setState({ detected: true });
+                    } else if (parseFloat(tY) < -this.state.delta) {
+                        if (this && this.props && this.props.onSwipedUp) this.props.onSwipedUp(true);
+                        this.setState({ detected: true });
                     }
                 }
             }
 
-            if(!this.state.detected){
-                if(Math.abs(parseFloat(tX))>=this.state.delta){
-                    if(parseFloat(tX)>this.state.delta){
-                        if(this && this.props && this.props.onSwipedRight) this.props.onSwipedRight(true);
-                        this.setState({detected: true});
-                    }
-                    else if(parseFloat(tX)<(-this.state.delta)){
-                        if(this && this.props && this.props.onSwipedLeft) this.props.onSwipedLeft(true);
-                        this.setState({detected: true});
-                    }
-                }
-                else{
-                    if(Math.abs(parseFloat(tY))>=this.state.delta){
-                        if(parseFloat(tY)>this.state.delta){
-                            if(this && this.props && this.props.onSwipedDown) this.props.onSwipedDown(true);
-                            this.setState({detected: true});
-                        }
-                        else if(parseFloat(tY)<(-this.state.delta)){
-                            if(this && this.props && this.props.onSwipedUp) this.props.onSwipedUp(true);
-                            this.setState({detected: true});
-                        }
-                    }
-                }
-            }
-
-            if(this.state.preventDefaultEvent) e.preventDefault();
+            if (this.state.preventDefaultEvent) e.preventDefault();
         }
-    },
-    _mouseEnd(e){
+    }
+
+    _mouseEnd(e) {
         this.setState({
             x: 0,
             y: 0,
             status: false,
             detected: false
         });
-        if(this.state.preventDefaultEvent) e.preventDefault();
-    },
+        if (this.state.preventDefaultEvent) e.preventDefault();
+    }
+
     _touchStart(e) {
-        if(this.props.preventDefaultEvent && this.props.preventDefaultEvent!==this.state.preventDefaultEvent) this.setState({preventDefaultEvent: this.props.preventDefaultEvent});
-        if(this.props.delta && this.props.delta!==this.state.delta) this.setState({delta: this.props.delta});
+        if (this.props.preventDefaultEvent && this.props.preventDefaultEvent !== this.state.preventDefaultEvent) {
+            this.setState({ preventDefaultEvent: this.props.preventDefaultEvent });
+        }
+        if (this.props.delta && this.props.delta !== this.state.delta) this.setState({ delta: this.props.delta });
 
         this.setState({
             x: Math.abs(e.touches[0].pageX).toFixed(2),
@@ -136,71 +124,62 @@ const Swipe = React.createClass({
             status: true,
             detected: false
         });
-        if(this.state.preventDefaultEvent) e.preventDefault();
-    },
+        if (this.state.preventDefaultEvent) e.preventDefault();
+    }
+
     _touchMove(e) {
         if (e.touches.length > 1) {
-            return
+            return;
         }
 
-        let x = (e.touches[0].pageX).toFixed(2);
-        let y = (e.touches[0].pageY).toFixed(2);
+        let x = e.touches[0].pageX.toFixed(2);
+        let y = e.touches[0].pageY.toFixed(2);
         let tX = parseFloat((x - this.state.x).toFixed(2));
         let tY = parseFloat((y - this.state.y).toFixed(2));
 
         if (Math.abs(tX) > Math.abs(tY) && this.props.onSwipe) this.props.onSwipe([tX, 0]);
         else if (Math.abs(tX) < Math.abs(tY) && this.props.onSwipe) this.props.onSwipe([0, tY]);
 
-
-        if(Math.abs(tX)>=this.state.delta){
-            if(tX>this.state.delta){
-                if(this && this.props && this.props.onSwipingRight) this.props.onSwipingRight(true);
-                if(this && this.props && this.props.right) this.props.right(true);
+        if (Math.abs(tX) >= this.state.delta) {
+            if (tX > this.state.delta) {
+                if (this && this.props && this.props.onSwipingRight) this.props.onSwipingRight(true);
+                if (this && this.props && this.props.right) this.props.right(true);
+            } else if (tX < -this.state.delta) {
+                if (this && this.props && this.props.onSwipingLeft) this.props.onSwipingLeft(true);
+                if (this && this.props && this.props.left) this.props.left(true);
             }
-            else if(tX<(-this.state.delta)){
-                if(this && this.props && this.props.onSwipingLeft) this.props.onSwipingLeft(true);
-                if(this && this.props && this.props.left) this.props.left(true);
-            }
-        }
-        else{
-            if(Math.abs(tY)>=this.state.delta){
-                if(tY>this.state.delta){
-                    if(this && this.props && this.props.onSwipingDown) this.props.onSwipingDown(true);
-                }
-                else if(tY<(-this.state.delta)){
-                    if(this && this.props && this.props.onSwipingUp) this.props.onSwipingUp(true);
-                    if(this && this.props && this.props.up) this.props.up(true);
-                }
+        } else if (Math.abs(tY) >= this.state.delta) {
+            if (tY > this.state.delta) {
+                if (this && this.props && this.props.onSwipingDown) this.props.onSwipingDown(true);
+            } else if (tY < -this.state.delta) {
+                if (this && this.props && this.props.onSwipingUp) this.props.onSwipingUp(true);
+                if (this && this.props && this.props.up) this.props.up(true);
             }
         }
 
-        if(!this.state.detected){
-            if(Math.abs(parseFloat(tX))>=this.state.delta){
-                if(parseFloat(tX)>this.state.delta){
-                    if(this && this.props && this.props.onSwipedRight) this.props.onSwipedRight(true);
-                    this.setState({detected: true});
+        if (!this.state.detected) {
+            if (Math.abs(parseFloat(tX)) >= this.state.delta) {
+                if (parseFloat(tX) > this.state.delta) {
+                    if (this && this.props && this.props.onSwipedRight) this.props.onSwipedRight(true);
+                    this.setState({ detected: true });
+                } else if (parseFloat(tX) < -this.state.delta) {
+                    if (this && this.props && this.props.onSwipedLeft) this.props.onSwipedLeft(true);
+                    this.setState({ detected: true });
                 }
-                else if(parseFloat(tX)<(-this.state.delta)){
-                    if(this && this.props && this.props.onSwipedLeft) this.props.onSwipedLeft(true);
-                    this.setState({detected: true});
-                }
-            }
-            else{
-                if(Math.abs(parseFloat(tY))>=this.state.delta){
-                    if(parseFloat(tY)>this.state.delta){
-                        if(this && this.props && this.props.onSwipedDown) this.props.onSwipedDown(true);
-                        this.setState({detected: true});
-                    }
-                    else if(parseFloat(tY)<(-this.state.delta)){
-                        if(this && this.props && this.props.onSwipedUp) this.props.onSwipedUp(true);
-                        this.setState({detected: true});
-                    }
+            } else if (Math.abs(parseFloat(tY)) >= this.state.delta) {
+                if (parseFloat(tY) > this.state.delta) {
+                    if (this && this.props && this.props.onSwipedDown) this.props.onSwipedDown(true);
+                    this.setState({ detected: true });
+                } else if (parseFloat(tY) < -this.state.delta) {
+                    if (this && this.props && this.props.onSwipedUp) this.props.onSwipedUp(true);
+                    this.setState({ detected: true });
                 }
             }
         }
 
-        if(this.state.preventDefaultEvent) e.preventDefault();
-    },
+        if (this.state.preventDefaultEvent) e.preventDefault();
+    }
+
     _touchEnd(e) {
         this.setState({
             x: 0,
@@ -208,8 +187,26 @@ const Swipe = React.createClass({
             status: false,
             detected: false
         });
-        if(this.state.preventDefaultEvent) e.preventDefault();
+        if (this.state.preventDefaultEvent) e.preventDefault();
     }
-});
+}
+
+Swipe.propTypes = {
+    nodeName: PropTypes.string,
+    mouseSwipe: PropTypes.bool,
+    className: PropTypes.string,
+    onSwipingUp: PropTypes.func,
+    onSwipingRight: PropTypes.func,
+    onSwipingDown: PropTypes.func,
+    onSwipingLeft: PropTypes.func,
+    onSwipedUp: PropTypes.func,
+    onSwipedRight: PropTypes.func,
+    onSwipedDown: PropTypes.func,
+    onSwipedLeft: PropTypes.func,
+    onSwipe: PropTypes.func,
+    delta: PropTypes.number,
+    preventDefaultEvent: PropTypes.bool,
+    style: PropTypes.object
+};
 
 module.exports = Swipe;

--- a/src/Swipe.js
+++ b/src/Swipe.js
@@ -1,23 +1,24 @@
 const React = require('react');
+const PropTypes = require('prop-types');
 
 const Swipe = React.createClass({
     displayName: 'Swipe',
     propTypes: {
-        nodeName: React.PropTypes.string,
-        mouseSwipe: React.PropTypes.bool,
-        className: React.PropTypes.string,
-        onSwipingUp: React.PropTypes.func,
-        onSwipingRight: React.PropTypes.func,
-        onSwipingDown: React.PropTypes.func,
-        onSwipingLeft: React.PropTypes.func,
-        onSwipedUp: React.PropTypes.func,
-        onSwipedRight: React.PropTypes.func,
-        onSwipedDown: React.PropTypes.func,
-        onSwipedLeft: React.PropTypes.func,
-        onSwipe: React.PropTypes.func,
-        delta: React.PropTypes.number,
-        preventDefaultEvent: React.PropTypes.bool,
-        style: React.PropTypes.object
+        nodeName: PropTypes.string,
+        mouseSwipe: PropTypes.bool,
+        className: PropTypes.string,
+        onSwipingUp: PropTypes.func,
+        onSwipingRight: PropTypes.func,
+        onSwipingDown: PropTypes.func,
+        onSwipingLeft: PropTypes.func,
+        onSwipedUp: PropTypes.func,
+        onSwipedRight: PropTypes.func,
+        onSwipedDown: PropTypes.func,
+        onSwipedLeft: PropTypes.func,
+        onSwipe: PropTypes.func,
+        delta: PropTypes.number,
+        preventDefaultEvent: PropTypes.bool,
+        style: PropTypes.object
     },
     getInitialState() {
         return {


### PR DESCRIPTION
Accessing PropTypes via the main React package is deprecated (v15.5.0+) - https://github.com/facebook/react/releases. Recommendation is to use the prop-types package from npm instead. This pull request applies those changes.

I've also switched from React.createClass to extending the React.component class - this is another thing that'd deprecated in 15.5.0