### PR TITLE
make swipe component able to receive React Node

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ render(<Demo/>, document.getElementById('app') );
 ### Props
 **```nodeName```** is a string which determines the html element/node that this react component binds its touch events to then returns. The default value is 'div'.
 
+**```node```** is a option if you'd like to pass a node instead of nodeName(e.g. styled-components).
+
 **```className```** is a string which determines the html element/node class.
 
 **```style```** is a object which determines the style for element.
@@ -103,6 +105,7 @@ render(<Demo/>, document.getElementById('app') );
 ```javascript
 {
   nodeName?: string,
+  node?: React.Node,
   className?: string,
   style?: Object,
 

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types'
 
 type Props = {
   nodeName?: string,
+  node?: React.Node,
   className?: string,
   style?: Object,
 
@@ -87,7 +88,7 @@ export default class Swipe extends React.Component<Props, State> {
       onMouseUp: this.props.mouseSwipe ? this.moveEnd : null,
     }
     newProps.style.touchAction = 'none'
-    return React.createElement(this.props.nodeName || 'div', newProps, this.props.children)
+    return React.createElement(this.props.nodeName || this.props.node || 'div', newProps, this.props.children)
   }
 
   _moveStart (e: Object) {


### PR DESCRIPTION
Hi

I thought I'd like to pass my styled component instead of nodeName & className combination (that is because I used the module styled-components).

`React.createElement` can receive anythings can be rendered so I could addressed my issue to pass the styled-component via `nodeName` and type incompatible.
I suppose this PR will solve that issue.

I'm not good at flowtype and also English to write a good README but hope it will help.

Thanks!